### PR TITLE
Add dependencies to BUILD.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,6 +3,9 @@ Building RedPhone
 
 1. Ensure the 'Android Support Repository' is installed from the Android SDK manager.
 1. Ensure gradle >= 1.9 is installed.
+1. Ensure Android 4.2.2 (API 17) is installed.
+1. Ensure Android SDK Build Tools r19 is installed.
+
 
 Execute Gradle:
 


### PR DESCRIPTION
The build requires specific versions of Android SDK and Android API which BUILD.md did not explain. This change adds them to help developers in the future.