### PR TITLE
Show incoming call over lockscreen, not requiring unlock to accept / reject

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -120,6 +120,8 @@
     <string name="preferences__general_settings">General Settings</string>
     <string name="preferences__prompt_for_call_upgrade">Prompt for call upgrade</string>
     <string name="preferences__when_making_insecure_calls_prompt_for_upgrade_to_redphone_if_contact_is_redphone_enabled">When making insecure calls, prompt for upgrade to RedPhone if contact is RedPhone-enabled.</string>
+    <string name="preferences__require_unlock">Require unlock to accept call</string>
+    <string name="preferences__require_unlock_summary">Require to unlock the device to accept an incoming call</string>
     <string name="preferences__advanced_audio_settings">Advanced: Audio Settings</string>
     <string name="preferences__disable_bluetooth">Enable Bluetooth</string>
     <string name="preferences__disable_bluetooth_summary">Disabling Bluetooth may resolve audio issues on some devices</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -6,6 +6,10 @@
                         android:key="pref_prompt_upgrade"
                         android:title="@string/preferences__prompt_for_call_upgrade"
                         android:summary="@string/preferences__when_making_insecure_calls_prompt_for_upgrade_to_redphone_if_contact_is_redphone_enabled"/>
+    <CheckBoxPreference android:defaultValue="false"
+                        android:key="pref_require_unlock"
+                        android:title="@string/preferences__require_unlock"
+                        android:summary="@string/preferences__require_unlock_summary"/>
   </PreferenceCategory>
   <PreferenceCategory android:title="@string/preferences__advanced_audio_settings">
     <CheckBoxPreference android:defaultValue="false"

--- a/src/org/thoughtcrime/redphone/RedPhone.java
+++ b/src/org/thoughtcrime/redphone/RedPhone.java
@@ -46,6 +46,7 @@ import org.thoughtcrime.redphone.codec.CodecSetupException;
 import org.thoughtcrime.redphone.contacts.PersonInfo;
 import org.thoughtcrime.redphone.crypto.zrtp.SASInfo;
 import org.thoughtcrime.redphone.directory.DirectoryUpdateReceiver;
+import org.thoughtcrime.redphone.ui.ApplicationPreferencesActivity;
 import org.thoughtcrime.redphone.ui.CallControls;
 import org.thoughtcrime.redphone.ui.CallScreen;
 import org.thoughtcrime.redphone.util.AudioUtils;
@@ -115,10 +116,12 @@ public class RedPhone extends Activity {
 
     startServiceIfNecessary();
     requestWindowFeature(Window.FEATURE_NO_TITLE);
-    getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON|
-            WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD|
-            WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED|
-            WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
+    if (!ApplicationPreferencesActivity.getRequireDeviceunlockPreference(this)) {
+      getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON |
+              WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD |
+              WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+              WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
+    }
     setContentView(R.layout.main);
 
     setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
@@ -207,7 +210,7 @@ public class RedPhone extends Activity {
   private void handleAnswerCall() {
     state = STATE_ANSWERING;
     callScreen.setActiveCall(redPhoneService.getRemotePersonInfo(),
-                             getString(R.string.RedPhone_answering));
+            getString(R.string.RedPhone_answering));
 
     Intent intent = new Intent(this, RedPhoneService.class);
     intent.setAction(RedPhoneService.ACTION_ANSWER_CALL);
@@ -234,7 +237,7 @@ public class RedPhone extends Activity {
   private void handleOutgoingCall(String remoteNumber) {
     state = STATE_DIALING;
     callScreen.setActiveCall(PersonInfo.getInstance(this, remoteNumber),
-                             getString(R.string.RedPhone_dialing));
+            getString(R.string.RedPhone_dialing));
   }
 
   private void handleTerminate( int terminationType ) {
@@ -285,7 +288,7 @@ public class RedPhone extends Activity {
 
   private void handleConnectingToInitiator() {
     callScreen.setActiveCall(redPhoneService.getRemotePersonInfo(),
-                             getString(R.string.RedPhone_connecting));
+            getString(R.string.RedPhone_connecting));
   }
 
   private void handleHandshakeFailed() {
@@ -304,20 +307,20 @@ public class RedPhone extends Activity {
 
   private void handlePerformingHandshake() {
     callScreen.setActiveCall(redPhoneService.getRemotePersonInfo(),
-                             getString(R.string.RedPhone_performing_handshake));
+            getString(R.string.RedPhone_performing_handshake));
   }
 
   private void handleServerFailure() {
     state = STATE_IDLE;
     callScreen.setActiveCall(redPhoneService.getRemotePersonInfo(),
-                              getString(R.string.RedPhone_server_failed_exclamation));
+            getString(R.string.RedPhone_server_failed_exclamation));
     delayedFinish();
   }
 
   private void handleClientFailure(String msg) {
     state = STATE_IDLE;
     callScreen.setActiveCall(redPhoneService.getRemotePersonInfo(),
-                             getString(R.string.RedPhone_client_failed));
+            getString(R.string.RedPhone_client_failed));
     if( msg != null && !isFinishing() ) {
       AlertDialog.Builder ad = new AlertDialog.Builder(this);
       ad.setTitle("Fatal Error");

--- a/src/org/thoughtcrime/redphone/RedPhone.java
+++ b/src/org/thoughtcrime/redphone/RedPhone.java
@@ -117,8 +117,7 @@ public class RedPhone extends Activity {
     startServiceIfNecessary();
     requestWindowFeature(Window.FEATURE_NO_TITLE);
     if (!ApplicationPreferencesActivity.getRequireDeviceunlockPreference(this)) {
-      getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON |
-              WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD |
+      getWindow().addFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD |
               WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
               WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
     }

--- a/src/org/thoughtcrime/redphone/RedPhone.java
+++ b/src/org/thoughtcrime/redphone/RedPhone.java
@@ -115,6 +115,10 @@ public class RedPhone extends Activity {
 
     startServiceIfNecessary();
     requestWindowFeature(Window.FEATURE_NO_TITLE);
+    getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON|
+            WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD|
+            WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED|
+            WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
     setContentView(R.layout.main);
 
     setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);

--- a/src/org/thoughtcrime/redphone/ui/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/redphone/ui/ApplicationPreferencesActivity.java
@@ -39,6 +39,7 @@ public class ApplicationPreferencesActivity extends SherlockPreferenceActivity {
 
   public static final String LOOPBACK_MODE_PREF         = "pref_loopback";
   public static final String OPPORTUNISTIC_UPGRADE_PREF = "pref_prompt_upgrade";
+  public static final String REQUIRE_DEVICE_UNLOCK_PREF = "pref_require_unlock";
   public static final String BLUETOOTH_ENABLED          = "pref_bluetooth_enabled";
 
   @Override
@@ -73,6 +74,11 @@ public class ApplicationPreferencesActivity extends SherlockPreferenceActivity {
   public static boolean getPromptUpgradePreference(Context context) {
     return PreferenceManager
            .getDefaultSharedPreferences(context).getBoolean(OPPORTUNISTIC_UPGRADE_PREF, true);
+  }
+
+  public static boolean getRequireDeviceunlockPreference(Context context) {
+    return PreferenceManager
+            .getDefaultSharedPreferences(context).getBoolean(REQUIRE_DEVICE_UNLOCK_PREF, true);
   }
 
   public static boolean getLoopbackEnabled(Context context) {


### PR DESCRIPTION
The old behavior can be enabled via preference setting, just in case anyone wants security over convenience.

This problem has been discussed in #358 and #191.