### PR TITLE
Disabling legacy zero'd CONFIRM IV compatibility

### DIFF
--- a/src/org/thoughtcrime/redphone/crypto/zrtp/ZRTPSocket.java
+++ b/src/org/thoughtcrime/redphone/crypto/zrtp/ZRTPSocket.java
@@ -197,8 +197,8 @@ public abstract class ZRTPSocket {
   // here, where we intentionally do the wrong thing for older devices.  We'll
   // phase this out after a couple of months.
   protected boolean isLegacyConfirmConnection() {
-    RedPhoneClientId clientId = new RedPhoneClientId(getForeignHello().getClientId());
-    return clientId.isLegacyConfirmConnectionVersion();
+    // [Sep 2015] This feature should be long obsolete by now. Disabling now, removing later.
+    return false;
   }
 
   protected void setState(int state) {


### PR DESCRIPTION
It's been long enough that there should be no more clients using a version that still zeroes the IV.

(Do we have any version-usage stats that would allow us to confirm this?)

This request takes the first step in the process of removing the should-be-unused compatibility code by unconditionally turning off the feature, but doesn't strip out the actual code.