### PR TITLE
All telephone numbers in the Faroe Islands (+298) are 6 digits and th…

### DIFF
--- a/src/org/thoughtcrime/redphone/util/PhoneNumberFormatter.java
+++ b/src/org/thoughtcrime/redphone/util/PhoneNumberFormatter.java
@@ -41,7 +41,7 @@ import java.util.Locale;
 public class PhoneNumberFormatter {
 
   public static boolean isValidNumber(String number) {
-    return number.matches("^\\+[0-9]{10,}");
+    return number.matches("^\\+[0-9]{9,}");
   }
 
   private static String impreciseFormatNumber(String number, String localNumber) {


### PR DESCRIPTION
All telephone numbers in the Faroe Islands (+298) are 6 digits and thus the current code fails every valid number.

Lowering the regexp limit to 9 digits would be appreciated very much. Thank you. :-)